### PR TITLE
Disable Conan on CI Aer build

### DIFF
--- a/.github/actions/install-master-dependencies/action.yml
+++ b/.github/actions/install-master-dependencies/action.yml
@@ -15,9 +15,15 @@ description: 'Installs Python dependencies from Master'
 
 runs:
   using: "composite"
-  steps: 
-    - run : |
+  steps:
+    - name: Install Dependencies from Master
+      env:
+        DISABLE_CONAN: 1
+      run: |
         pip install https://github.com/Qiskit/qiskit-terra/archive/master.zip
         pip install https://github.com/Qiskit/qiskit-optimization/archive/master.zip
+        sudo apt-get -y install nlohmann-json3-dev
+        sudo apt-get -y install libspdlog-dev
+        sudo apt-get -y install libmuparserx-dev
         pip install https://github.com/Qiskit/qiskit-aer/archive/master.zip
       shell: bash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ html_static_path = ['_static']
 templates_path = ['_templates']
 html_css_files = ['style.css', 'custom.css', 'gallery.css']
 
-nbsphinx_timeout = 180
+nbsphinx_timeout = 360
 nbsphinx_execute = os.getenv('QISKIT_DOCS_BUILD_TUTORIALS', 'never')
 nbsphinx_widgets_path = ''
 exclude_patterns = ['_build', '**.ipynb_checkpoints']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments
Conan downloads dependencies from JFrog Bintray that goes down sometimes. This disables Conan and installs dependencies in the CI.

