### PR TITLE
Run tutorials from stable branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,7 @@ jobs:
         shell: bash
       - name: Run make html
         run:  |
+          make clean_sphinx
           make html SPHINXOPTS=-W
           cd docs/_build/html
           mkdir artifacts
@@ -185,6 +186,34 @@ jobs:
         with:
           name: tutorials${{ matrix.python-version }}
           path: docs/_build/html/artifacts/tutorials.tar.gz
+      - name: Run stable tutorials
+        env:
+          QISKIT_PARALLEL: False
+          QISKIT_DOCS_BUILD_TUTORIALS: 'always'
+        run: |
+          # clean last sphinx output
+          make clean_sphinx
+          # get current version
+          version=$(pip show qiskit-finance | awk -F. '/^Version:/ { print substr($1,10), $2-1 }' OFS=.)
+          # download stable version
+          wget https://codeload.github.com/Qiskit/qiskit-finance/zip/stable/$version -O /tmp/repo.zip
+          unzip /tmp/repo.zip -d /tmp/
+          # copy stable tutorials to main tutorials
+          rm -rf docs/tutorials/*
+          cp -R /tmp/qiskit-finance-stable-$version/docs/tutorials/* docs/tutorials
+          # run tutorials and zip results
+          make html SPHINXOPTS=-W
+          cd docs/_build/html
+          mkdir artifacts
+          tar -zcvf artifacts/tutorials.tar.gz --exclude=./artifacts .
+        if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
+        shell: bash
+      - name: Run upload stable tutorials
+        uses: actions/upload-artifact@v2
+        with:
+          name: tutorials-stable${{ matrix.python-version }}
+          path: docs/_build/html/artifacts/tutorials.tar.gz
+        if: ${{ matrix.python-version == 3.8 && !startsWith(github.ref, 'refs/heads/stable') && !startsWith(github.base_ref, 'stable/') }}
   Deprecation_Messages_and_Coverage:
     needs: [Checks, Lint, Finance, Tutorials]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ endif
 # You can set this variable from the command line.
 SPHINXOPTS    =
 
-.PHONY: lint mypy style test test_ci spell copyright html doctest coverage coverage_erase
+.PHONY: lint mypy style black test test_ci spell copyright html doctest clean_sphinx coverage coverage_erase clean
 
-all_check: spell style lint copyright mypy html doctest
+all_check: spell style lint copyright mypy clean_sphinx html doctest
 
 lint:
 	pylint -rn qiskit_finance test tools
@@ -70,6 +70,9 @@ html:
 
 doctest:
 	make -C docs doctest SPHINXOPTS=$(SPHINXOPTS)
+
+clean_sphinx:
+	make -C docs clean
 	
 coverage:
 	coverage3 run --source qiskit_finance -m unittest discover -s test -q
@@ -78,4 +81,4 @@ coverage:
 coverage_erase:
 	coverage erase
 
-clean: coverage_erase ;
+clean: clean_sphinx coverage_erase; 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,15 +22,15 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 spell:
-	rm -rf $(BUILDDIR)
-	rm -rf $(STUBSDIR)
 	@$(SPHINXBUILD) -M spelling "$(SOURCEDIR)" "$(BUILDDIR)" -W $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+clean:
+	rm -rf $(BUILDDIR)
+	rm -rf $(STUBSDIR)
+
+.PHONY: help spell clean Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	rm -rf $(BUILDDIR)
-	rm -rf $(STUBSDIR)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Add one CI step that runs the stable branch tutorials against current main versions of the repos.
This ensures we properly deprecate changed api.
The tutorials run against python 3.8 only which is the current version used to upload them.

Add additional make rule to clean the docs _build/stubs folder.


### Details and comments


