### PR TITLE
Update deprecated `Distributions` imports (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ evaluate a fixed income asset with uncertain interest rates.
 import numpy as np
 from qiskit import BasicAer
 from qiskit.algorithms import AmplitudeEstimation, EstimationProblem
-from qiskit.circuit.library import NormalDistribution
+from qiskit_finance.circuit.library import NormalDistribution
 from qiskit_finance.applications import FixedIncomeExpectedValue
 
 # Create a suitable multivariate distribution

--- a/qiskit_finance/circuit/library/probability_distributions/gaussian_conditional_independence_model.py
+++ b/qiskit_finance/circuit/library/probability_distributions/gaussian_conditional_independence_model.py
@@ -17,7 +17,8 @@ import numpy as np
 from scipy.stats.distributions import norm
 
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit.library import LinearPauliRotations, NormalDistribution
+from qiskit.circuit.library import LinearPauliRotations
+from .normal import NormalDistribution
 
 
 class GaussianConditionalIndependenceModel(QuantumCircuit):

--- a/test/circuit/test_european_call_delta_objective.py
+++ b/test/circuit/test_european_call_delta_objective.py
@@ -17,11 +17,12 @@ from test import QiskitFinanceTestCase
 
 import numpy as np
 
-from qiskit.circuit.library import IntegerComparator, LogNormalDistribution
+from qiskit.circuit.library import IntegerComparator
 from qiskit.quantum_info import Operator
-
 from qiskit.utils import QuantumInstance
 from qiskit.algorithms import IterativeAmplitudeEstimation, EstimationProblem
+from qiskit_finance.circuit.library import LogNormalDistribution
+
 from qiskit_finance.circuit.library.payoff_functions import EuropeanCallDeltaObjective
 
 

--- a/test/circuit/test_european_call_pricing_objective.py
+++ b/test/circuit/test_european_call_pricing_objective.py
@@ -17,12 +17,11 @@ from test import QiskitFinanceTestCase
 
 import numpy as np
 
-from qiskit.circuit.library import TwoLocal, NormalDistribution
 from qiskit.utils import algorithm_globals, QuantumInstance
 from qiskit.algorithms import IterativeAmplitudeEstimation, EstimationProblem
-from qiskit.circuit.library import LinearAmplitudeFunction
+from qiskit.circuit.library import LinearAmplitudeFunction, TwoLocal
 from qiskit.quantum_info import Operator
-from qiskit_finance.circuit.library import EuropeanCallPricingObjective
+from qiskit_finance.circuit.library import EuropeanCallPricingObjective, NormalDistribution
 
 
 class TestEuropeanCallExpectedValue(QiskitFinanceTestCase):

--- a/test/circuit/test_fixed_income_pricing_objective.py
+++ b/test/circuit/test_fixed_income_pricing_objective.py
@@ -20,8 +20,8 @@ import numpy as np
 from qiskit import QuantumCircuit
 from qiskit.utils import QuantumInstance
 from qiskit.algorithms import IterativeAmplitudeEstimation, EstimationProblem
-from qiskit.circuit.library import NormalDistribution
 from qiskit.quantum_info import Operator
+from qiskit_finance.circuit.library import NormalDistribution
 from qiskit_finance.circuit.library.payoff_functions import FixedIncomePricingObjective
 
 

--- a/test/test_readme_sample.py
+++ b/test/test_readme_sample.py
@@ -38,7 +38,7 @@ class TestReadmeSample(QiskitFinanceTestCase):
         import numpy as np
         from qiskit import BasicAer
         from qiskit.algorithms import AmplitudeEstimation
-        from qiskit.circuit.library import NormalDistribution
+        from qiskit_finance.circuit.library import NormalDistribution
         from qiskit_finance.applications import FixedIncomePricing
 
         # Create a suitable multivariate distribution


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #66

* Update deprecated `Distributions` imports

### Details and comments

* `Distributions` were moved out of the qiskit circuit library to the circuit library here in finance. This fix changes the imports to deprecated `Distributions` in the qiskit to new `Distributions` in the qiskit-finance and solve some warnings.
