### PR TITLE
Bump reno requirement to latest version and set default_branch

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,2 +1,3 @@
 ---
 encoding: utf8
+default_branch: main

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pylint>=2.8.3
 pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
-reno>=3.2.0
+reno>=3.4.0
 Sphinx>=1.8.3,!=3.1.0
 sphinx-panels
 sphinx-gallery


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When we created a stable branch for qiskit-finance we encountered
a bug in reno that required a branch named master to exist for traversing
the git history. To workaround that issue we temporarily added back a
branch named master while we waited for the fix [1] to be included in a
release. A new reno release has been published [2] and we can rely on
that version and delete the idle master branch now. This commit makes
this change and switches to using reno>=3.4.0 and uses the new
default_branch configuration option added in 3.4.0 to fix the issue.

### Details and comments

[1] https://opendev.org/openstack/reno/commit/ed6bbae82e01edf781534d9e9cce21e0c55a49a6
[2] https://pypi.org/project/reno/3.4.0/