### PR TITLE
Pandas 1.4.0 breaks Yahoo Finance library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ psutil>=5
 scikit-learn>=0.20.0
 fastdtw
 setuptools>=40.1.0
-pandas
+pandas<1.4.0
 quandl
 yfinance>=0.1.62


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Pandas 1.4.0 released on 01/22/2022 breaks Yahoo Finance library.
Pinning pandas < 1.4.0 until Yahoo Finance library gets fixed.


### Details and comments


