### PR TITLE
Pin Windows CI version to 2019

### DIFF
--- a/.github/actions/install-finance/action.yml
+++ b/.github/actions/install-finance/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps: 
     - run : |
-        if [ "${{ inputs.os }}" == "windows-latest" ]; then
+        if [ "${{ inputs.os }}" == "windows-2019" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi

--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Install Dependencies from Main
       run: |
-        if [ "${{ inputs.os }}" == "windows-latest" ]; then
+        if [ "${{ inputs.os }}" == "windows-2019" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi
@@ -33,7 +33,7 @@ runs:
           sudo apt-get -y install libspdlog-dev
           sudo apt-get -y install libmuparserx-dev
         fi
-        if [ "${{ inputs.os }}" == "windows-latest" ]; then
+        if [ "${{ inputs.os }}" == "windows-2019" ]; then
           git clone https://github.com/Qiskit/qiskit-aer.git /tmp/qiskit-aer
           pushd /tmp/qiskit-aer
           python setup.py bdist_wheel -- -G 'Visual Studio 16 2019'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -32,7 +32,7 @@ runs:
       env:
         PYTHONWARNINGS: default
       run: |
-        if [ "${{ inputs.os }}" == "windows-latest" ]; then
+        if [ "${{ inputs.os }}" == "windows-2019" ]; then
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate scsenv
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,9 +111,9 @@ jobs:
             python-version: 3.8
           - os: macos-latest
             python-version: '3.10'
-          - os: windows-latest
+          - os: windows-2019
             python-version: 3.8
-          - os: windows-latest
+          - os: windows-2019
             python-version: '3.10'
     steps:
       - uses: actions/checkout@v2
@@ -126,7 +126,7 @@ jobs:
           conda create -n scsenv python=${{ matrix.python-version }}
           conda activate scsenv
           conda install -y scs lapack cvxpy -c conda-forge
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows-2019' }}
         shell: bash
       - uses: ./.github/actions/install-main-dependencies
         with:
@@ -137,7 +137,7 @@ jobs:
           os: ${{ matrix.os }}
       - name: Run lint
         run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          if [ "${{ matrix.os }}" == "windows-2019" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -145,7 +145,7 @@ jobs:
         shell: bash
       - name: Run mypy
         run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          if [ "${{ matrix.os }}" == "windows-2019" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -154,7 +154,7 @@ jobs:
         shell: bash
       - name: Run lint latest version
         run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          if [ "${{ matrix.os }}" == "windows-2019" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -171,7 +171,7 @@ jobs:
         if: ${{ !cancelled() }}
       - name: Deprecation Messages
         run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          if [ "${{ matrix.os }}" == "windows-2019" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -180,7 +180,7 @@ jobs:
         shell: bash
       - name: Coverage combine
         run: |
-          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+          if [ "${{ matrix.os }}" == "windows-2019" ]; then
             source "$CONDA/etc/profile.d/conda.sh"
             conda activate scsenv
           fi
@@ -301,11 +301,11 @@ jobs:
           path: /tmp/m310
       - uses: actions/download-artifact@v2
         with:
-          name: windows-latest-3.8
+          name: windows-2019-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v2
         with:
-          name: windows-latest-3.10
+          name: windows-2019-3.10
           path: /tmp/w310
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Recent CI release of Windows 2022 breaks Terra main build. Pinning to previous 2019 for now.


### Details and comments


