### PR TITLE
Fix data provider docstring formatting

### DIFF
--- a/qiskit_finance/data_providers/exchange_data_provider.py
+++ b/qiskit_finance/data_providers/exchange_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_finance/data_providers/exchange_data_provider.py
+++ b/qiskit_finance/data_providers/exchange_data_provider.py
@@ -47,13 +47,13 @@ class ExchangeDataProvider(BaseDataProvider):
         end: datetime.datetime = datetime.datetime(2016, 1, 30),
     ) -> None:
         """
-        Initializer
         Args:
-            token: quandl access token
+            token: Quandl access token
             tickers: tickers
             stockmarket: LONDON, EURONEXT, or SINGAPORE
             start: first data point
             end: last data point precedes this date
+
         Raises:
             MissingOptionalLibraryError: Quandl not installed
             QiskitFinanceError: provider doesn't support given stock market

--- a/qiskit_finance/data_providers/random_data_provider.py
+++ b/qiskit_finance/data_providers/random_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_finance/data_providers/random_data_provider.py
+++ b/qiskit_finance/data_providers/random_data_provider.py
@@ -42,12 +42,12 @@ class RandomDataProvider(BaseDataProvider):
         seed: Optional[int] = None,
     ) -> None:
         """
-        Initializer
         Args:
             tickers: tickers
             start: first data point
             end: last data point precedes this date
-            seed: shall a seed be used?
+            seed: optional random seed
+
         Raises:
             MissingOptionalLibraryError: Pandas not installed
         """

--- a/qiskit_finance/data_providers/wikipedia_data_provider.py
+++ b/qiskit_finance/data_providers/wikipedia_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2021.
+# (C) Copyright IBM 2019, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_finance/data_providers/wikipedia_data_provider.py
+++ b/qiskit_finance/data_providers/wikipedia_data_provider.py
@@ -46,13 +46,13 @@ class WikipediaDataProvider(BaseDataProvider):
         end: datetime.datetime = datetime.datetime(2016, 1, 30),
     ) -> None:
         """
-        Initializer
         Args:
             token: quandl access token, which is not needed, strictly speaking
             tickers: tickers
             start: start time
             end: end time
-         Raises:
+
+        Raises:
             MissingOptionalLibraryError: Quandl not installed
         """
         super().__init__()

--- a/qiskit_finance/data_providers/yahoo_data_provider.py
+++ b/qiskit_finance/data_providers/yahoo_data_provider.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_finance/data_providers/yahoo_data_provider.py
+++ b/qiskit_finance/data_providers/yahoo_data_provider.py
@@ -45,11 +45,11 @@ class YahooDataProvider(BaseDataProvider):
         end: datetime.datetime = datetime.datetime(2016, 1, 30),
     ) -> None:
         """
-        Initializer
         Args:
             tickers: tickers
             start: start time
             end: end time
+
         Raises:
             MissingOptionalLibraryError: YFinance not installed
         """


### PR DESCRIPTION
Fix docstrings of data providers so the html of the API reference is correctly formatted as its not now e.g.

![image](https://user-images.githubusercontent.com/40241007/151429673-63640a41-d09b-4765-9311-714fd16c12c0.png)


