### PR TITLE
Drop `pandas` requirement restriction

### DIFF
--- a/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
+++ b/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
@@ -1,0 +1,11 @@
+---
+upgrade:
+  - |
+   Drop pandas minimum version requirement restriction and increase yfinance minimum version
+   to 0.1.70. 
+   The bug that broke yfinance upon upgrading to pandas>=1.4.0 has been fixed 
+   in the release version 0.1.70.
+   As such, it should be safe to drop the restriction and permit newer versions of pandas.
+   Related Github links:
+    * https://github.com/ranaroussi/yfinance/releases/tag/0.1.70
+    * https://github.com/ranaroussi/yfinance/issues/937

--- a/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
+++ b/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
@@ -5,7 +5,7 @@ upgrade:
    to 0.1.70. 
    The bug that broke yfinance upon upgrading to pandas>=1.4.0 has been fixed 
    in the release version 0.1.70.
-   As such, it should be safe to drop the restriction and permit newer versions of pandas.
    Related links:
+   
    * https://github.com/ranaroussi/yfinance/releases/tag/0.1.70
    * https://github.com/ranaroussi/yfinance/issues/937

--- a/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
+++ b/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
@@ -6,6 +6,6 @@ upgrade:
    The bug that broke yfinance upon upgrading to pandas>=1.4.0 has been fixed 
    in the release version 0.1.70.
    As such, it should be safe to drop the restriction and permit newer versions of pandas.
-   Related Github links:
+   Related links:
    * https://github.com/ranaroussi/yfinance/releases/tag/0.1.70
    * https://github.com/ranaroussi/yfinance/issues/937

--- a/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
+++ b/releasenotes/notes/pandas-restriction-0965815429fd8877.yaml
@@ -7,5 +7,5 @@ upgrade:
    in the release version 0.1.70.
    As such, it should be safe to drop the restriction and permit newer versions of pandas.
    Related Github links:
-    * https://github.com/ranaroussi/yfinance/releases/tag/0.1.70
-    * https://github.com/ranaroussi/yfinance/issues/937
+   * https://github.com/ranaroussi/yfinance/releases/tag/0.1.70
+   * https://github.com/ranaroussi/yfinance/issues/937

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ psutil>=5
 scikit-learn>=0.20.0
 fastdtw
 setuptools>=40.1.0
-pandas<1.4.0
+pandas
 quandl
-yfinance>=0.1.62
+yfinance>=0.1.70


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

It should be safe to drop the restriction on the `pandas` dependency that was introduced because of #133 by using the most recent version of `yfinance`.

### Details and comments

The bug that broke `yfinance` upon upgrading to `pandas>=1.4.0` (see #133) has been fixed in the release of version `0.1.70` (see https://github.com/ranaroussi/yfinance/releases/tag/0.1.70 and the corresponding issue https://github.com/ranaroussi/yfinance/issues/937). As such, it should be safe to drop the restriction and permit newer versions of pandas.

