### PR TITLE
Skip Nasdaq Data Link test if token not provided

### DIFF
--- a/qiskit_finance/data_providers/exchange_data_provider.py
+++ b/qiskit_finance/data_providers/exchange_data_provider.py
@@ -93,6 +93,9 @@ class ExchangeDataProvider(BaseDataProvider):
             except nasdaqdatalink.AuthenticationError as ex:
                 logger.debug(ex, exc_info=True)
                 raise QiskitFinanceError("Nasdaq Data Link invalid token.") from ex
+            except nasdaqdatalink.LimitExceededError as ex:
+                logger.debug(ex, exc_info=True)
+                raise QiskitFinanceError("Nasdaq Data Link limit exceeded.") from ex
             except nasdaqdatalink.NotFoundError as ex:
                 logger.debug(ex, exc_info=True)
                 stocks_notfound.append(name)

--- a/qiskit_finance/data_providers/wikipedia_data_provider.py
+++ b/qiskit_finance/data_providers/wikipedia_data_provider.py
@@ -76,6 +76,9 @@ class WikipediaDataProvider(BaseDataProvider):
             except nasdaqdatalink.AuthenticationError as ex:
                 logger.debug(ex, exc_info=True)
                 raise QiskitFinanceError("Nasdaq Data Link invalid token.") from ex
+            except nasdaqdatalink.LimitExceededError as ex:
+                logger.debug(ex, exc_info=True)
+                raise QiskitFinanceError("Nasdaq Data Link limit exceeded.") from ex
             except nasdaqdatalink.NotFoundError as ex:
                 logger.debug(ex, exc_info=True)
                 stocks_notfound.append(name)

--- a/test/circuit/test_european_call_delta_objective.py
+++ b/test/circuit/test_european_call_delta_objective.py
@@ -16,7 +16,6 @@ import unittest
 from test import QiskitFinanceTestCase
 
 import numpy as np
-import qiskit
 from qiskit.circuit.library import IntegerComparator
 from qiskit.quantum_info import Operator
 from qiskit.utils import QuantumInstance, optionals
@@ -95,8 +94,11 @@ class TestEuropeanCallDelta(QiskitFinanceTestCase):
         )
 
         # run amplitude estimation
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         q_i = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             seed_simulator=125,
             seed_transpiler=80,
         )

--- a/test/circuit/test_european_call_pricing_objective.py
+++ b/test/circuit/test_european_call_pricing_objective.py
@@ -16,7 +16,6 @@ import unittest
 from test import QiskitFinanceTestCase
 
 import numpy as np
-import qiskit
 from qiskit.utils import algorithm_globals, QuantumInstance, optionals
 from qiskit.algorithms import IterativeAmplitudeEstimation, EstimationProblem
 from qiskit.circuit.library import LinearAmplitudeFunction, TwoLocal
@@ -102,8 +101,11 @@ class TestEuropeanCallExpectedValue(QiskitFinanceTestCase):
             post_processing=european_call.post_processing,
         )
 
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         q_i = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             seed_simulator=125,
             seed_transpiler=80,
         )

--- a/test/circuit/test_fixed_income_pricing_objective.py
+++ b/test/circuit/test_fixed_income_pricing_objective.py
@@ -17,7 +17,6 @@ from test import QiskitFinanceTestCase
 
 import numpy as np
 
-import qiskit
 from qiskit import QuantumCircuit
 from qiskit.utils import QuantumInstance, optionals
 from qiskit.algorithms import IterativeAmplitudeEstimation, EstimationProblem
@@ -89,8 +88,11 @@ class TestFixedIncomePricingObjective(QiskitFinanceTestCase):
         )
 
         # run simulation
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         q_i = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             seed_simulator=2,
             seed_transpiler=2,
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #198 

The Nasdaq Data Link tests will be skipped if token is not provided in an env.variable. Since a token is personal and not provided in the CI, the CI will always skip those tests. In case a token is provided, any error will fail the unit test.

For Wikipedia provider a token is not mandatory. In that case, any error will fail unit test unless it is a daily data usage exceeded in which case it will be skipped.


### Details and comments


