### PR TITLE
Yahoo Finance download single thread to avoid database lock

### DIFF
--- a/qiskit_finance/data_providers/yahoo_data_provider.py
+++ b/qiskit_finance/data_providers/yahoo_data_provider.py
@@ -71,7 +71,7 @@ class YahooDataProvider(BaseDataProvider):
                 start=self._start,
                 end=self._end,
                 group_by="ticker",
-                # threads=False,
+                threads=False,
                 progress=logger.isEnabledFor(logging.DEBUG),
             )
             if len(self._tickers) == 1:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Random database lock when downloading Yahoo Finance data in multithread mode.


### Details and comments


