### PR TITLE
Remove unnecessary `html_theme_path` option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,6 @@ import os
 import sys
 from datetime import date
 
-sys.path.insert(0, os.path.abspath(".."))
 sys.path.append(os.path.abspath("."))
 
 """
@@ -86,13 +85,6 @@ nbsphinx_prolog += link_str + "{{ docname }}"
 
 # -- General configuration ---------------------------------------------------
 
-# If your documentation needs a minimal Sphinx version, state it here.
-#
-# needs_sphinx = '1.0'
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
@@ -181,18 +173,8 @@ modindex_common_prefix = ["qiskit_finance."]
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-#
 html_theme = "qiskit_sphinx_theme"
 
-html_theme_path = [".", qiskit_sphinx_theme.get_html_theme_path()]
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#
 html_theme_options = {
     "logo_only": False,
     "display_version": True,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `qiskit_sphinx_theme` package will soon have "variants" that allow setting the theme to either Core (Terra) or Ecosystem. 

As prework for that, I plan to deprecate/remove the function `qiskit_sphinx_theme.get_html_theme_path()`, as it no longer will make semantic sense when we have multiple HTML themes in the package.

Turns out, setting `html_theme_path` isn't necessary in the first place. It looks like bad (or outdated) copy-and-paste from old blogs.

### Details and comments

The Qiskit Finance docs render the same before and after this change.