### PR TITLE
Revert path change in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ import os
 import sys
 from datetime import date
 
+sys.path.insert(0, os.path.abspath(".."))
 sys.path.append(os.path.abspath("."))
 
 """


### PR DESCRIPTION
This reverts a path change that was done by #244 

This change was not done on the other application repos. Without it the deploy_translatable_strings part of the deploy-docs workflow fails

```
Running Sphinx v5.3.0

Traceback (most recent call last):
  File "/home/runner/work/qiskit-finance/qiskit-finance/docs/.tox/docs/lib/python3.8/site-packages/sphinx/config.py", line 350, in eval_config_file
    exec(code, namespace)
  File "/home/runner/work/qiskit-finance/qiskit-finance/docs/conf.py", line 37, in <module>
    import qiskit_finance
ModuleNotFoundError: No module named 'qiskit_finance'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/qiskit-finance/qiskit-finance/docs/.tox/docs/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/runner/work/qiskit-finance/qiskit-finance/docs/.tox/docs/lib/python3.8/site-packages/sphinx/application.py", line 202, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
  File "/home/runner/work/qiskit-finance/qiskit-finance/docs/.tox/docs/lib/python3.8/site-packages/sphinx/config.py", line 172, in read
    namespace = eval_config_file(filename, tags)
  File "/home/runner/work/qiskit-finance/qiskit-finance/docs/.tox/docs/lib/python3.8/site-packages/sphinx/config.py", line 363, in eval_config_file
    raise ConfigError(msg % traceback.format_exc()) from exc
sphinx.errors.ConfigError: There is a programmable error in your configuration file:
```