### PR TITLE
Update readme to use Sampler instead of now deprecated QuantumInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-finance.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)<!--- long-description-skip-begin -->[![Build Status](https://github.com/Qiskit/qiskit-finance/workflows/Finance%20Unit%20Tests/badge.svg?branch=main)](https://github.com/Qiskit/qiskit-finance/actions?query=workflow%3A"Finance%20Unit%20Tests"+branch%3Amain+event%3Apush)[![](https://img.shields.io/github/release/Qiskit/qiskit-finance.svg?style=popout-square)](https://github.com/Qiskit/qiskit-finance/releases)[![](https://img.shields.io/pypi/dm/qiskit-finance.svg?style=popout-square)](https://pypi.org/project/qiskit-finance/)[![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-finance/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-finance?branch=main)<!--- long-description-skip-end -->
 
 **Qiskit Finance** is an open-source framework that contains uncertainty components for stock/securities problems,
-Ising translators for portfolio optimizations and data providers to source real or random data to
+applications, such as portfolio optimization, and data providers to source real or random data to
 finance experiments.
 
 ## Installation
@@ -33,8 +33,8 @@ evaluate a fixed income asset with uncertain interest rates.
 
 ```python
 import numpy as np
-from qiskit import BasicAer
 from qiskit.algorithms import AmplitudeEstimation
+from qiskit.primitives import Sampler
 from qiskit_finance.circuit.library import NormalDistribution
 from qiskit_finance.applications import FixedIncomePricing
 
@@ -65,8 +65,8 @@ problem = fixed_income.to_estimation_problem()
 num_eval_qubits = 5
 
 # Construct and run amplitude estimation
-q_i = BasicAer.get_backend("statevector_simulator")
-algo = AmplitudeEstimation(num_eval_qubits=num_eval_qubits, quantum_instance=q_i)
+sampler = Sampler()
+algo = AmplitudeEstimation(num_eval_qubits=num_eval_qubits, sampler=sampler)
 result = algo.estimate(problem)
 
 print(f"Estimated value:\t{fixed_income.interpret(result):.4f}")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #278

Replaced QuantumInstance usage by Sampler in README sample program.

Also updated the main description a little.

### Details and comments


