### PR TITLE
Add project urls to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,10 @@ setuptools.setup(
     install_requires=REQUIREMENTS,
     include_package_data=True,
     python_requires=">=3.7",
+    project_urls={
+        "Bug Tracker": "https://github.com/Qiskit/qiskit-finance/issues",
+        "Documentation": "https://qiskit.org/ecosystem/finance/",
+        "Source Code": "https://github.com/Qiskit/qiskit-finance",
+    },
     zip_safe=False
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds project urls to setup so that PyPI project page has more than just a `Homepage` url. This adds additional project urls comparable to qiskit-terra i.e. `Bug Tracker`, `Documentation` and `Source Code`.

As per Qiskit/qiskit-optimization#523

I marked this for backport, since I imagine a bug fix release, that would include #263, once Qiskit Optimzation does its next minor release.

### Details and comments


